### PR TITLE
Moving from sigint to sigterm for killing server

### DIFF
--- a/lib/WWW/Mechanize/PhantomJS/Catalyst.pm
+++ b/lib/WWW/Mechanize/PhantomJS/Catalyst.pm
@@ -55,7 +55,7 @@ sub DESTROY
     if ($self->server_pid) {
         local $?;
         print STDERR "[$$] Waiting for Catalyst server [", $self->server_pid, "] to finish..\n" if $self->debug;
-        kill 2, $self->server_pid;
+        kill 15, $self->server_pid;
         local $SIG{PIPE} = 'IGNORE';
         close $self->server;
     }


### PR DESCRIPTION
Servers usually ignore sigint, and catalyst sometimes hangs forever.  But if we switch to sigterm (the normal signal to signal graceful shutdown), the hangs go away.
